### PR TITLE
Add NEW_VERSION option

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -8,5 +8,5 @@ search = version="{current_version}"
 replace = version="{new_version}"
 
 [bumpversion:file:README.md]
-search = jaumann/github-tag-action@{current_version}
-replace = jaumann/github-tag-action@{new_version}
+search = jaumann/github-bumpversion-action@v{current_version}
+replace = jaumann/github-bumpversion-action@v{new_version}

--- a/.hadolint.yml
+++ b/.hadolint.yml
@@ -1,0 +1,3 @@
+ignored:
+  - DL3018 # pin apk packages version
+  - DL3013 # pin pip packages version

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ jobs:
 * **DEFAULT_BUMP** *(optional)* - Which type of bump to use when none explicitly provided (default: `minor`).
 * **SOURCE** *(optional)* - Operate on a relative path under $GITHUB_WORKSPACE.
 * **DRY_RUN** *(optional)* - Determine the next version without tagging the branch. The workflow can use the outputs `new_tag` and `tag` in subsequent steps. Possible values are ```true``` and ```false``` (default).
+* **NEW_VERSION** *(optional)* - New version that should be in the files.
 
 
 ### Outputs

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Bump version and push tag
-        uses: jaumann/github-tag-action@0.0.6
+        uses: jaumann/github-bumpversion-action@v0.0.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Push changes

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,7 @@
 default_semvar_bump=${DEFAULT_BUMP:-patch}
 source=${SOURCE:-.}
 dryrun=${DRY_RUN:-false}
+new_version=${NEW_VERSION:-""}
 
 cd "${GITHUB_WORKSPACE}/${source}" || return
 
@@ -39,7 +40,13 @@ case "$log" in
   * ) part="$default_semvar_bump";;
 esac
 
-raw_output=$(bumpversion --list "$part" --dry-run)
+# check if new version is already specified
+if [ -z "$new_version" ]; then
+  raw_output=$(bumpversion --list "$part" --dry-run)
+else
+  raw_output=$(bumpversion --list "$part" --dry-run --new-version="$new_version")
+fi
+
 old_version=$(echo "$raw_output" | grep -o 'current_version=\S*' | cut -d= -f2)
 new_version=$(echo "$raw_output" | grep -o 'new_version=\S*' | cut -d= -f2)
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -67,5 +67,5 @@ if [ "$dryrun" = true ]; then
 else
   git config --global user.email "bumpversion@github-actions"
   git config --global user.name "BumpVersion Action"
-  bumpversion "$part" --verbose
+  bumpversion "$part" --new-version="$new_version" --verbose
 fi


### PR DESCRIPTION
Changes made:
- Update repo and version (`v` missing) in the README for the action example
- Use `--new-version` arg to specify your own version instead of letting `bumpversion` determine that for you. If unspecified the action will work as before
- Added `.hadolint.yml` to ignore `pin pip` / `pin apk` packages warning.

The reason for adding `NEW_VERSION` is I'd like to use this to action update all the files that need a version update only, but the bumping of the version I'll be using something different which will always bump version from the latest git tag. 